### PR TITLE
remove max-width of table header

### DIFF
--- a/suomen-vaylat-app/src/components/gfi/GfiTabContentItem.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GfiTabContentItem.jsx
@@ -75,7 +75,6 @@ const StyledGfiTabContentItemTableRow = styled.tr`
 `;
 
 const StyledGfiTabContentItemTableHeader = styled.th`
-    max-width: 100px;
     padding-left: 16px;
     font-size: 14px;
     font-weight: 600;


### PR DESCRIPTION
Remove max-width so the table scales properly and text doesn't overlap because of it not wrapping correctly