### PR TITLE
Zoom in or out to show layer text link

### DIFF
--- a/suomen-vaylat-app/src/translations/en.json
+++ b/suomen-vaylat-app/src/translations/en.json
@@ -265,6 +265,7 @@
       "layerVisible": "Layer visible",
       "zoomInToShowLayer": "Zoom in to see the map layer",
       "zoomOutToShowLayer": "Zoom out to see the map layer",
+      "toShowLayer" : "to see the map layer",
       "opacity": "Transparency"
     }
   },

--- a/suomen-vaylat-app/src/translations/fi.json
+++ b/suomen-vaylat-app/src/translations/fi.json
@@ -265,6 +265,7 @@
       "layerVisible": "Taso näkyvillä",
       "zoomInToShowLayer": "Lähennä nähdäksesi taso",
       "zoomOutToShowLayer": "Loitonna nähdäksesi taso",
+      "toShowLayer" : "nähdäksesi taso",
       "opacity": "Läpinäkyvyys"
     }
   },

--- a/suomen-vaylat-app/src/translations/sv.json
+++ b/suomen-vaylat-app/src/translations/sv.json
@@ -265,6 +265,7 @@
       "layerVisible": "Lager synligt",
       "zoomInToShowLayer": "Zooma in för att se kartlagret",
       "zoomOutToShowLayer": "Zooma ut för att se kartlagret",
+      "toShowLayer" : "för att se kartlagret",
       "opacity": "Genomskinlighet"
     }
   },


### PR DESCRIPTION
- Make "zoom in to show layer" or "zoom out to show layer" text clickable so it zooms to a proper zoomlevel and makes the layer visible.