### PR TITLE
Switch react-data-table to ka-table

### DIFF
--- a/suomen-vaylat-app/package-lock.json
+++ b/suomen-vaylat-app/package-lock.json
@@ -5,8 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "suomen-vaylat-app",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
         "@fortawesome/free-solid-svg-icons": "^5.15.3",
@@ -25,6 +24,7 @@
         "framer-motion": "^4.1.17",
         "history": "4.10.1",
         "i18n-json-to-xlsx-converter": "^2.0.0",
+        "ka-table": "^7.3.0",
         "lodash.throttle": "^4.1.1",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.33",
@@ -4269,6 +4269,8 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
       "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4283,7 +4285,9 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -8052,19 +8056,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -10329,6 +10320,14 @@
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/ka-table": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ka-table/-/ka-table-7.3.0.tgz",
+      "integrity": "sha512-cDIsZSDI8B2W9sJQl5hgtoCQsJvUSlxj2LTk8SaSYGdMse3ToRC8LoC27QqbRzy7x4n92yV4/wzrTesGguNlqA==",
+      "peerDependencies": {
+        "react": "^16.8.3 || ^17.0.0-0"
       }
     },
     "node_modules/kind-of": {
@@ -20190,14 +20189,13 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.10.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
           "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -20208,7 +20206,9 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -22997,12 +22997,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "optional": true
-    },
     "fstream": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
@@ -24690,6 +24684,12 @@
           }
         }
       }
+    },
+    "ka-table": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ka-table/-/ka-table-7.3.0.tgz",
+      "integrity": "sha512-cDIsZSDI8B2W9sJQl5hgtoCQsJvUSlxj2LTk8SaSYGdMse3ToRC8LoC27QqbRzy7x4n92yV4/wzrTesGguNlqA==",
+      "requires": {}
     },
     "kind-of": {
       "version": "6.0.3",
@@ -26902,8 +26902,7 @@
       "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.5.7"
+        "invariant": "^2.2.4"
       }
     },
     "react-styled": {
@@ -28333,7 +28332,6 @@
         "is-glob": "^4.0.3",
         "normalize-path": "^3.0.0",
         "object-hash": "^2.2.0",
-        "postcss": "^8.4.6",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.0",
         "postcss-nested": "5.0.6",

--- a/suomen-vaylat-app/package-lock.json
+++ b/suomen-vaylat-app/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "suomen-vaylat-app",
       "version": "1.3.0",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^1.2.35",
@@ -4269,8 +4270,6 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
       "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -4285,9 +4284,7 @@
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "optional": true,
-      "peer": true
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -20189,13 +20186,14 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-      "requires": {},
+      "requires": {
+        "ajv": "^8.0.0"
+      },
       "dependencies": {
         "ajv": {
-          "version": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
           "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
-          "optional": true,
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -20206,9 +20204,7 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "optional": true,
-          "peer": true
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         }
       }
     },
@@ -26902,7 +26898,8 @@
       "integrity": "sha512-JZUw7hBsAHXK7PTyErJyI7SopSBFRcFHDjWW5SWjcugY0i6iH7f+eJkY8cJmGMlZ1C9xz1J3Vjz0plFpavVeRg==",
       "requires": {
         "@babel/runtime": "^7.2.0",
-        "invariant": "^2.2.4"
+        "invariant": "^2.2.4",
+        "prop-types": "^15.5.7"
       }
     },
     "react-styled": {
@@ -28332,6 +28329,7 @@
         "is-glob": "^4.0.3",
         "normalize-path": "^3.0.0",
         "object-hash": "^2.2.0",
+        "postcss": "^8.4.6",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.0",
         "postcss-nested": "5.0.6",

--- a/suomen-vaylat-app/package.json
+++ b/suomen-vaylat-app/package.json
@@ -20,6 +20,7 @@
     "framer-motion": "^4.1.17",
     "history": "4.10.1",
     "i18n-json-to-xlsx-converter": "^2.0.0",
+    "ka-table": "^7.3.0",
     "lodash.throttle": "^4.1.1",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.33",

--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -233,11 +233,11 @@ const StyledTabContent = styled.div`
         -webkit-user-select: text;  /* Chrome / Safari */
         -moz-user-select: text;     /* Firefox */
         -ms-user-select: text;      /* IE 10+ */
-        user-select: text;  
+        user-select: text;
         max-height: 150px;
         overflow: hidden;
     }
-    
+
     .ka-thead-cell-content, .ka-cell-text {
         overflow: hidden;
         text-overflow: ellipsis;
@@ -245,6 +245,12 @@ const StyledTabContent = styled.div`
 
     .low-priority-table {
         margin-left: 0px;
+    }
+
+    .ka-thead-cell-content {
+        font-size: 14px;
+        font-weight: 600;
+        color: #212529;
     }
 `;
 
@@ -312,7 +318,6 @@ export const GFIPopup = ({ handleGfiDownload }) => {
                 return contentDiv;
             }
             else if (location.type === 'geojson') {
-                // THIS IS ACTUALLY NOT USED?
                 return <FormattedGFI
                     id={layerIds}
                     data={location.content}
@@ -391,13 +396,16 @@ export const GFIPopup = ({ handleGfiDownload }) => {
         var columnsArray = [];
 
         var columns = hightPriorityColumns.concat(lowPriorityColumns);
-        columns.forEach(coulmn => {
-            columnsArray.push({ key: coulmn, title: coulmn, colGroup: { style: { minWidth: 120 } }});
+        columns.forEach(column => {
+            if (column !== 'UID') {
+                columnsArray.push({ key: column, title: column, colGroup: { style: { minWidth: 120 } }});
+            }
         });
 
         var cells = data && data.content && data.content.features && data.content.features.map(feature => {
                 var cell = {...feature.properties};
                 cell['id'] = feature.id;
+                cell.hasOwnProperty('UID') && delete cell['UID'];
                 cell.hasOwnProperty('_orderHigh') && delete cell['_orderHigh'];
                 cell.hasOwnProperty('_order') && delete cell['_order'];
                 return cell;
@@ -406,7 +414,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
         const tablePropsInit = {
             columns: columnsArray,
             data: cells,
-            rowKeyField: '',
+            rowKeyField: 'id',
             sortingMode: SortingMode.SingleTripleState,
             columnResizing: true,
             paging: {

--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -27,6 +27,8 @@ import GfiToolsMenu from './GfiToolsMenu';
 import GfiDownloadMenu from './GfiDownloadMenu';
 import CircleButton from '../circle-button/CircleButton';
 
+import { SortingMode, PagingPosition } from 'ka-table/enums';
+
 // Max amount of features that wont trigger react-data-table-component
 const GFI_MAX_LENGTH = 5;
 const KUNTA_IMAGE_URL = 'https://www.kuntaliitto.fi/sites/default/files/styles/narrow_320_x_600_/public/media/profile_pictures/';
@@ -217,25 +219,28 @@ const StyledTabContent = styled.div`
         padding-right: 15px;
     }
 
-    td:nth-child(even) {
-    }
-
-    td:nth-child(odd) {
-        border-right: 1px solid #ddd;
-    }
-
     table {
         border-top: 1px solid #ddd;
         padding-right: 0px !important;
         width: 100%;
     }
 
-    tr:nth-child(2n) {
-        background-color: #f2f2f2;
+    .ka-thead-cell {
+        background-color: white;
     }
 
-    table tr {
-        border-bottom: 1px solid #ddd;
+    .ka-cell-text {
+        -webkit-user-select: text;  /* Chrome / Safari */
+        -moz-user-select: text;     /* Firefox */
+        -ms-user-select: text;      /* IE 10+ */
+        user-select: text;  
+        max-height: 150px;
+        overflow: hidden;
+    }
+    
+    .ka-thead-cell-content, .ka-cell-text {
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .low-priority-table {
@@ -244,6 +249,7 @@ const StyledTabContent = styled.div`
 `;
 
 const StyledButtonsContainer = styled.div`
+    margin-top: auto;
     padding: 16px;
     z-index: 1;
     display: flex;
@@ -306,6 +312,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
                 return contentDiv;
             }
             else if (location.type === 'geojson') {
+                // THIS IS ACTUALLY NOT USED?
                 return <FormattedGFI
                     id={layerIds}
                     data={location.content}
@@ -376,6 +383,42 @@ export const GFIPopup = ({ handleGfiDownload }) => {
         setIsVKMInfoOpen(!isVKMInfoOpen);
     };
 
+    const tablePropsInit = (data) => {
+        const properties = data && data.content && data.content.features && data.content.features[0].properties;
+
+        var hightPriorityColumns = properties._orderHigh && JSON.parse(properties._orderHigh);
+        var lowPriorityColumns = properties._order && JSON.parse(properties._order);
+        var columnsArray = [];
+
+        var columns = hightPriorityColumns.concat(lowPriorityColumns);
+        columns.forEach(coulmn => {
+            columnsArray.push({ key: coulmn, title: coulmn, colGroup: { style: { minWidth: 120 } }});
+        });
+
+        var cells = data && data.content && data.content.features && data.content.features.map(feature => {
+                var cell = {...feature.properties};
+                cell['id'] = feature.id;
+                cell.hasOwnProperty('_orderHigh') && delete cell['_orderHigh'];
+                cell.hasOwnProperty('_order') && delete cell['_order'];
+                return cell;
+        });
+
+        const tablePropsInit = {
+            columns: columnsArray,
+            data: cells,
+            rowKeyField: '',
+            sortingMode: SortingMode.SingleTripleState,
+            columnResizing: true,
+            paging: {
+              enabled: true,
+              pageIndex: 0,
+              pageSize: 10,
+              pageSizes: [10, 50, 100],
+              position: PagingPosition.Bottom
+            },
+        };
+        return tablePropsInit;
+    }
 
     const handleGfiToolsMenu = () => {
         setIsGfiDownloadsOpen(false);
@@ -661,6 +704,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
                     {gfiLocations.map((location) => {
                             const layers = allLayers.filter(layer => layer.id === location.layerId);
                             const title = layers.length > 0 && layers[0].name;
+                            const tableProps = tablePropsInit(location);
                             if (location.type === 'geojson') {
                                 return (
                                     <SwiperSlide
@@ -684,6 +728,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
                                         <GfiTabContent
                                             data={location}
                                             title={title}
+                                            tablePropsInit={tableProps}
                                         />
                                     </SwiperSlide>
                                 );

--- a/suomen-vaylat-app/src/components/gfi/GfiTabContent.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GfiTabContent.jsx
@@ -1,13 +1,13 @@
 import { useState, useEffect } from 'react';
 import styled from 'styled-components';
 
-import DataTable from "react-data-table-component";
-
 import GfiTabContentItem from './GfiTabContentItem';
 
 import { faTable, faList } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
+import { kaReducer, Table } from 'ka-table';
+import "ka-table/style.scss";
 
 const StyledSelectedTabHeader = styled.div`
     position: relative;
@@ -39,48 +39,31 @@ const StyledSelectedTabDisplayOptionsButton = styled.div`
     };
 `;
 
-const customStyles = {
-    rows: {
-        style: {
-            whiteSpace: 'unset',
-            overflow: 'unset',
-            textOverflow: 'unset',
-            '&:hover': {
-                backgroundColor: '#f0f0f0',
-                'div *': {
-                    fontSize: '14px',
-                    fontWeight: '600',
-                    whiteSpace: 'unset',
-                  }
-              },
-        },
-    },
-    headCells: {
-        style: {
-            fontSize: '14px',
-            fontWeight: '600',
-            'div *': {
-                whiteSpace: 'unset',
-                overflow: 'unset',
-                textOverflow: 'unset'
-            }
-        },
-    },
-    cells: {
-        style: {
-            color: '#646464',
-            userSelect: 'text'
-        },
-    },
-};
+const StyledTabContent = styled.div`
+    td:nth-child(odd) {
+        border-right: 1px solid #ddd;
+    }
+
+    tr:nth-child(2n) {
+        background-color: #f2f2f2;
+    }
+
+    table tr {
+        border-bottom: 1px solid #ddd;
+    }
+`;
+
 
 const GfiTabContent = ({
     data,
-    title
+    title,
+    tablePropsInit
 }) => {
-
-    const [tableColumns, setTableColumns] = useState([]);
-    const [tableCells, setTableCells] = useState([]);
+    
+    const [tableProps, changeTableProps] = useState(tablePropsInit);
+    const dispatch = action => {
+      changeTableProps(prevState => kaReducer(prevState, action));
+    };
 
     const [showDataTable, setShowDataTable] = useState(data.content && data.content.features && data.content.features.length > 5);
 
@@ -141,32 +124,6 @@ const GfiTabContent = ({
         ]);
     };
 
-    useEffect(() => {
-        const properties = data && data.content && data.content.features && data.content.features[0].properties;
-
-        var hightPriorityColumns = properties._orderHigh && JSON.parse(properties._orderHigh);
-        var lowPriorityColumns = properties._order && JSON.parse(properties._order);
-
-        var columns = hightPriorityColumns.concat(lowPriorityColumns);
-        var cells = data && data.content && data.content.features && data.content.features.map(feature => {
-                var cell = {...feature.properties};
-                cell['id'] = feature.id;
-                cell.hasOwnProperty('_orderHigh') && delete cell['_orderHigh'];
-                cell.hasOwnProperty('_order') && delete cell['_order'];
-                return cell;
-        });
-
-        setTableColumns(columns.map(property => {
-                  return property !== 'UID' && {
-                  name: property,
-                  selector: row => row[property],
-                  sortable: true,
-              }
-        }));
-
-         setTableCells(cells);
-    },[data]);
-
     return <>
             <StyledSelectedTabHeader>
                 <StyledSelectedTabTitle>
@@ -184,30 +141,29 @@ const GfiTabContent = ({
             </StyledSelectedTabHeader>
 
         {
-             showDataTable ?
-                <DataTable
-                    columns={tableColumns}
-                    data={tableCells}
-                    fixedHeader
-                    fixedHeaderScrollHeight="100%"
-                    customStyles={customStyles}
+            showDataTable ?
+                <Table
+                    {...tableProps}
+                    dispatch={dispatch}
                 />
             :
             <div style={{
                 overflow: 'auto'
             }}>
-                {
-                                data.content && data.content.features && data.content.features.map((feature, index) => {
-                                    return <GfiTabContentItem
-                                        key={feature.id}
-                                        title={feature.id.split(".")[1] ? title+" "+feature.id.split(".")[1] : title+" "+feature.id}
-                                        data={feature}
-                                        index={index}
-                                        selectFeature={selectFeature}
-                                        deSelectFeature={deSelectFeature}
-                                    />
-                                })
-                }
+                <StyledTabContent>
+                    {
+                        data.content && data.content.features && data.content.features.map((feature, index) => {
+                            return <GfiTabContentItem
+                                    key={feature.id}
+                                    title={feature.id.split(".")[1] ? title+" "+feature.id.split(".")[1] : title+" "+feature.id}
+                                    data={feature}
+                                    index={index}
+                                    selectFeature={selectFeature}
+                                    deSelectFeature={deSelectFeature}
+                                />
+                            })
+                    }
+                </StyledTabContent>
             </div>
 
         }

--- a/suomen-vaylat-app/src/components/gfi/GfiTabContent.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GfiTabContent.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 
 import GfiTabContentItem from './GfiTabContentItem';
@@ -59,7 +59,7 @@ const GfiTabContent = ({
     title,
     tablePropsInit
 }) => {
-    
+
     const [tableProps, changeTableProps] = useState(tablePropsInit);
     const dispatch = action => {
       changeTableProps(prevState => kaReducer(prevState, action));
@@ -155,7 +155,7 @@ const GfiTabContent = ({
                         data.content && data.content.features && data.content.features.map((feature, index) => {
                             return <GfiTabContentItem
                                     key={feature.id}
-                                    title={feature.id.split(".")[1] ? title+" "+feature.id.split(".")[1] : title+" "+feature.id}
+                                    title={feature.id.split('.')[1] ? title + ' ' + feature.id.split('.')[1] : title + ' ' + feature.id}
                                     data={feature}
                                     index={index}
                                     selectFeature={selectFeature}

--- a/suomen-vaylat-app/src/components/gfi/GfiTabContentItem.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GfiTabContentItem.jsx
@@ -67,7 +67,7 @@ const StyledGfiTabContentItemCollapseContent = styled(motion.div)`
 `;
 
 const StyledGfiTabContentItemTable = styled.table`
-   
+
 `;
 
 const StyledGfiTabContentItemTableRow = styled.tr`
@@ -108,7 +108,7 @@ const GfiTabContentItem = ({
         var hightPriorityFields = data.properties._orderHigh && JSON.parse(data.properties._orderHigh);
         var lowPriorityFields = data.properties._order && JSON.parse(data.properties._order);
 
-        if(hightPriorityFields.length > 0){
+        if (hightPriorityFields.length > 0) {
             hightPriorityFields && setOrderHigh(hightPriorityFields);
             lowPriorityFields && lowPriorityFields.length > 0 && setOrderLow(lowPriorityFields);
         } else if(lowPriorityFields.length > 0){
@@ -173,13 +173,13 @@ const GfiTabContentItem = ({
                         >
                             <StyledGfiTabContentItemTable>
                                 {
-                                    orderHigh ? orderHigh.map(value => {
-                                        return <StyledGfiTabContentItemTableRow key={value+'_'+data.properties[value]}>
+                                    orderHigh ? orderHigh.filter(value => value !== 'UID').map(value => {
+                                        return <StyledGfiTabContentItemTableRow key={value + '_' + data.properties[value]}>
                                             <StyledGfiTabContentItemTableHeader>{value}</StyledGfiTabContentItemTableHeader>
                                             <StyledGfiTabContentItemTableData>{data.properties[value]}</StyledGfiTabContentItemTableData>
                                         </StyledGfiTabContentItemTableRow>
-                                    }) : orderLow && orderLow.map(value => {
-                                            return <StyledGfiTabContentItemTableRow key={value+'_'+data.properties[value]}>
+                                    }) : orderLow && orderLow.filter(value => value !== 'UID').map(value => {
+                                            return <StyledGfiTabContentItemTableRow key={value + '_' + data.properties[value]}>
                                                 <StyledGfiTabContentItemTableHeader>{value}</StyledGfiTabContentItemTableHeader>
                                                 <StyledGfiTabContentItemTableData>{data.properties[value]}</StyledGfiTabContentItemTableData>
                                             </StyledGfiTabContentItemTableRow>

--- a/suomen-vaylat-app/src/components/menus/hierarchical-layerlist/ThemeLayerList.jsx
+++ b/suomen-vaylat-app/src/components/menus/hierarchical-layerlist/ThemeLayerList.jsx
@@ -238,7 +238,7 @@ export const ThemeLayerList = ({
     };
 
     useEffect(() => {
-        if(currentZoomLevel < selectedTheme?.minZoomLevel ) store.dispatch(setZoomTo(selectedTheme.minZoomLevel));
+        if (currentZoomLevel < selectedTheme?.minZoomLevel) store.dispatch(setZoomTo(selectedTheme.minZoomLevel));
     }, [selectedTheme]);
 
     return (

--- a/suomen-vaylat-app/src/components/menus/selected-layers/SelectedLayer.jsx
+++ b/suomen-vaylat-app/src/components/menus/selected-layers/SelectedLayer.jsx
@@ -8,7 +8,6 @@ import { updateLayers } from '../../../utils/rpcUtil';
 import { sortableHandle } from 'react-sortable-hoc';
 
 import strings from '../../../translations';
-import { current } from '@reduxjs/toolkit';
 
 const StyledLayerContainer = styled.li`
     z-index: 9999;
@@ -288,11 +287,11 @@ export const SelectedLayer = ({
                         }
                     </StyledlayerHeader>
                     <StyledMidContent>
-                        {isCurrentZoomTooFar || isCurrentZoomTooClose ? <StyledLayerInfoContainer> 
+                        {isCurrentZoomTooFar || isCurrentZoomTooClose ? <StyledLayerInfoContainer>
                             <StyledShowLayerButton onClick={() => store.dispatch(setZoomTo(layer.minZoomLevel))}>
                                 {isCurrentZoomTooFar? strings.tooltips.zoomIn : isCurrentZoomTooClose && strings.tooltips.zoomOut}
                             </StyledShowLayerButton> <p>{strings.layerlist.selectedLayers.toShowLayer}</p>
-                        </StyledLayerInfoContainer> 
+                        </StyledLayerInfoContainer>
                         : layerInfoText }
                     </StyledMidContent>
                     <StyledBottomContent>


### PR DESCRIPTION
Switched react-data-table to ka-table so we can modify column size
Paging is now set to show 10, 50 or 100 results
Should have the same functions as the old one, now also you can unset the column sorting (up, down, none)