### PR TITLE
Fix zoom bar not closing when setting mainscreen

### DIFF
--- a/suomen-vaylat-app/src/state/slices/uiSlice.tsx
+++ b/suomen-vaylat-app/src/state/slices/uiSlice.tsx
@@ -47,6 +47,7 @@ export const uiSlice = createSlice({
             state.isUserGuideOpen = false;
             state.isDrawingToolsOpen = false;
             state.isLegendOpen = false;
+            state.isZoomBarOpen = false;
             state.isSaveViewOpen = false;
             state.selectedMapLayersMenuTab = 0;
             state.selectedMapLayersMenuThemeIndex = null;


### PR DESCRIPTION
Close zoom bar when clicking app name on top left corner