### PR TITLE
Mobile fixes

### DIFF
--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -271,6 +271,7 @@ const StyledTabContent = styled.div`
 
     .ka-thead-cell {
         background-color: white;
+        width: ${(props) => props.isMobile ? "10em" : "auto"};
     }
 
     .ka-cell-text {
@@ -743,7 +744,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
                     )}
                 </StyledTabSwiperContainer>
             )}
-            <StyledTabContent>
+            <StyledTabContent isMobile={isMobile}>
                 {tabsContent[selectedTab] === undefined && (
                     <StyledNoGfisContainer>
                         <StyledSubtitle>{strings.gfi.choosingGfi}:</StyledSubtitle>

--- a/suomen-vaylat-app/src/components/modals/Modal.jsx
+++ b/suomen-vaylat-app/src/components/modals/Modal.jsx
@@ -10,6 +10,8 @@ import { setMinimizeGfi, setMaximizeGfi } from '../../state/slices/uiSlice';
 
 import { isMobile } from '../../theme/theme';
 
+const MIN_SCREEN_WIDTH_MAXIMIZE = 500;
+
 const StyledModalBackdrop = styled(motion.div)`
     z-index: ${(props) => (props.type === 'warning' ? 9998 : 10)};
     position: fixed;
@@ -271,7 +273,7 @@ const Modal = ({
                                                 />
                                             </StyledHeaderButton>
                                             {
-                                                !isMobile &&
+                                                window.screen.width > MIN_SCREEN_WIDTH_MAXIMIZE &&
                                                     <StyledHeaderButton
                                                         onClick={(e) => {
                                                             e.preventDefault();

--- a/suomen-vaylat-app/src/theme/theme.js
+++ b/suomen-vaylat-app/src/theme/theme.js
@@ -23,7 +23,7 @@ var isMobileTest = {
       return (isMobileTest.Android() || isMobileTest.BlackBerry() || isMobileTest.iOS() || isMobileTest.iPad() || isMobileTest.Opera() || isMobileTest.Windows());
   }};
 
-  export const isMobile = isMobileTest.any();
+export const isMobile = isMobileTest.any();
 
 const size = {
   mobileS: '320px',


### PR DESCRIPTION
- Fix scaling on ka-table (fixed column width, min, width doesn't seem to work properly)
- Allow maximize on devices with window screen with over 500 (basically enable it for tablets), because we need it for tablets but it is unnecessary for phones, "isMobile" variable doesn't differentiate between phones and tablets.

If window.screen.width is problematic then better to just remove the condition altogether