### PR TITLE
Remove unnecessary animation

### DIFF
--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -691,6 +691,9 @@ export const GFIPopup = ({ handleGfiDownload }) => {
                 )}
             </AnimatePresence>
                 <StyledVKMDataContainer
+                    initial={{
+                        height: !isVKMInfoOpen && !vkmData && 0
+                    }}
                     animate={{
                         height: isVKMInfoOpen ? 'auto' : 0,
                         opacity: isVKMInfoOpen ? 1 : 0,


### PR DESCRIPTION
Remove unnecessary animation when opening GFIPopup with no vkmData available