### PR TITLE
Tablet style fixes and improvements & crash handling

### DIFF
--- a/suomen-vaylat-app/public/index.html
+++ b/suomen-vaylat-app/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="rgb(0, 100, 175)" />
     <meta
       name="description"

--- a/suomen-vaylat-app/src/components/app-info-modal/AppInfoModalContent.jsx
+++ b/suomen-vaylat-app/src/components/app-info-modal/AppInfoModalContent.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState, useEffect} from 'react';
 import styled from 'styled-components';
 import strings from '../../translations';
 import { getAppBuildDate, getAppVersion } from '../../utils/appInfoUtil';
-import { isMobile} from '../../theme/theme';
+import { isMobile, size} from '../../theme/theme';
 import { motion, AnimatePresence } from 'framer-motion';
 
 import { Swiper, SwiperSlide } from 'swiper/react';
@@ -263,6 +263,8 @@ export const AppInfoModalContent = () => {
     const inputEl = useRef(null);
     const [isNavOpen, setIsNavOpen] = useState(true);
 
+    const showMobileView = isMobile && window.innerWidth < parseInt(size.mobileL);
+
     // App build info
     const currentAppVersion = getAppVersion();
     const currentAppBuildDate = getAppBuildDate();
@@ -270,7 +272,7 @@ export const AppInfoModalContent = () => {
     const [tabIndex, setTabIndex] = useState(0);
 
     useEffect(() => {
-        isMobile && setTabIndex(-1);
+        showMobileView && setTabIndex(-1);
     }, [])
 
     const tabsContent = [
@@ -325,11 +327,11 @@ export const AppInfoModalContent = () => {
     return (
         <>
             <StyledContent>
-                {isMobile && 
+                {showMobileView && 
                 <>
                     <StyledMenuContainer key="menuContainer">
                         <StyledCloseMenuContainer>
-                            <StyledCloseMenuIcon onClick={() => setIsNavOpen(!isNavOpen)} icon={!isNavOpen && faArrowLeft} />
+                            {!isNavOpen && <StyledCloseMenuIcon onClick={() => setIsNavOpen(!isNavOpen)} icon={faArrowLeft} />}
                         </StyledCloseMenuContainer>
                     </StyledMenuContainer>
                     <StyledMobileContainer
@@ -371,7 +373,7 @@ export const AppInfoModalContent = () => {
                 </>
                 }
 
-                {!isMobile &&
+                {!showMobileView &&
                     <StyledTabs
                     tabIndex={tabIndex}
                     tabsCount={tabsContent.length}
@@ -403,7 +405,7 @@ export const AppInfoModalContent = () => {
                         setTabIndex(e.activeIndex);
                     }}
                     allowTouchMove={false} // Disable swiping
-                    speed={isMobile? 0 : 300}
+                    speed={showMobileView? 0 : 300}
                 >
                     {
                         tabsContent.map((tab, index) => {
@@ -413,10 +415,10 @@ export const AppInfoModalContent = () => {
                                     key={'ai_tab_content_' + index}
                                 >
                                     <AnimatePresence>
-                                        {isMobile && !isNavOpen ? 
-                                        <StyledMobileTabContent key={'tabContent_' + index} variants={isMobile && variants} initial="initial" animate={isNavOpen ? "hidden" : "visible"} exit="exit">
+                                        {showMobileView && !isNavOpen ? 
+                                        <StyledMobileTabContent key={'tabContent_' + index} variants={showMobileView && variants} initial="initial" animate={isNavOpen ? "hidden" : "visible"} exit="exit">
                                         {tab.content}
-                                        </StyledMobileTabContent> : !isMobile && tab.content
+                                        </StyledMobileTabContent> : !showMobileView && tab.content
                                     }
                                     </AnimatePresence>
                                     </SwiperSlide>

--- a/suomen-vaylat-app/src/components/layout/Content.jsx
+++ b/suomen-vaylat-app/src/components/layout/Content.jsx
@@ -89,9 +89,6 @@ const StyledContent = styled.div`
         }
     };
     @media ${props => props.theme.device.tablet} {
-        .Toastify__toast-container {
-            width: 80%;
-        }
         .Toastify__toast-container--top-right {
             top: 9em;
         }

--- a/suomen-vaylat-app/src/components/measurement-tools/DrawingTools.jsx
+++ b/suomen-vaylat-app/src/components/measurement-tools/DrawingTools.jsx
@@ -46,12 +46,8 @@ const StyledToastIcon = styled(FontAwesomeIcon)`
     color: ${theme.colors.mainColor1};
 `;
 
-const StyledMarkerWrapper = styled.div`
-    
-`;
-
 const StyledOptionsWrapper = styled(motion.div)`
-    position: fixed;
+    position: absolute;
     background-color: ${props => props.theme.colors.mainWhite};
     z-index: -1;
     display: grid;
@@ -415,7 +411,7 @@ export const DrawingTools = ({isOpen}) => {
                                 tooltipDirection={"right"}
                             >
                             </CircleButton> : tool.id === "sv-add-marker" &&
-                            <StyledMarkerWrapper>
+                            <div>
                                 {tool.name && tool.name === activeTool &&
                                 <StyledOptionsWrapper>
                                     <StyledOptionButtonsWrapper>
@@ -440,7 +436,7 @@ export const DrawingTools = ({isOpen}) => {
                                 }
                                 <CircleButton type="drawingTool" showOptions={true} key={tool.id} icon={faMapMarkerAlt} text={tool.name} clickAction={() => addMarker(tool)}
                                 toggleState={tool.name && tool.name === activeTool ? true : false} tooltipDirection="right" />
-                            </StyledMarkerWrapper>
+                            </div>
                     )
                 })}
                 <AddGeometryButton

--- a/suomen-vaylat-app/src/components/measurement-tools/DrawingTools.jsx
+++ b/suomen-vaylat-app/src/components/measurement-tools/DrawingTools.jsx
@@ -46,13 +46,16 @@ const StyledToastIcon = styled(FontAwesomeIcon)`
     color: ${theme.colors.mainColor1};
 `;
 
+const StyledMarkerWrapper = styled.div`
+    
+`;
+
 const StyledOptionsWrapper = styled(motion.div)`
-    position: absolute;
-    left: 0};
-    bottom: 5px;
+    position: fixed;
     background-color: ${props => props.theme.colors.mainWhite};
     z-index: -1;
     display: grid;
+    bottom: 40px;
     grid-template-columns: 1fr;
     grid-gap: 5px;
     margin-left: 55px;
@@ -71,7 +74,7 @@ const StyledOptionsWrapper = styled(motion.div)`
     };
     @media ${props => props.theme.device.mobileL} {
         margin-left: 45px;
-        bottom: -45px;
+        bottom: -15px;
         svg {
 
         };
@@ -412,7 +415,7 @@ export const DrawingTools = ({isOpen}) => {
                                 tooltipDirection={"right"}
                             >
                             </CircleButton> : tool.id === "sv-add-marker" &&
-                            <div>
+                            <StyledMarkerWrapper>
                                 {tool.name && tool.name === activeTool &&
                                 <StyledOptionsWrapper>
                                     <StyledOptionButtonsWrapper>
@@ -437,7 +440,7 @@ export const DrawingTools = ({isOpen}) => {
                                 }
                                 <CircleButton type="drawingTool" showOptions={true} key={tool.id} icon={faMapMarkerAlt} text={tool.name} clickAction={() => addMarker(tool)}
                                 toggleState={tool.name && tool.name === activeTool ? true : false} tooltipDirection="right" />
-                            </div>
+                            </StyledMarkerWrapper>
                     )
                 })}
                 <AddGeometryButton

--- a/suomen-vaylat-app/src/components/menus/hierarchical-layerlist/LayerListTEMP.jsx
+++ b/suomen-vaylat-app/src/components/menus/hierarchical-layerlist/LayerListTEMP.jsx
@@ -147,7 +147,7 @@ const LayerListTEMP = ({
             {strings.layerlist.layerlistLabels.filterByType}
           </StyledListSubtitle>
           <StyledFiltersContainer>
-            {tags.map((tag, index) => {
+            {tags?.map((tag, index) => {
               return(
                   <Filter isOpen={isOpen} key={'fiter-tag-'+index} filter={tag} />
               );

--- a/suomen-vaylat-app/src/components/menus/hierarchical-layerlist/ThemeLayerList.jsx
+++ b/suomen-vaylat-app/src/components/menus/hierarchical-layerlist/ThemeLayerList.jsx
@@ -243,7 +243,7 @@ export const ThemeLayerList = ({
 
     return (
         <>
-            {allThemes.map((theme, index) => {
+            {allThemes?.map((theme, index) => {
                    return <ThemeGroup
                         key={index}
                         theme={theme}

--- a/suomen-vaylat-app/src/components/toasts/SearchToast.jsx
+++ b/suomen-vaylat-app/src/components/toasts/SearchToast.jsx
@@ -12,9 +12,12 @@ const StyledContainer = styled.div`
         height: 60vh;
         overflow: auto;
     };
-
     @media ${(props) => props.theme.device.mobileL} {
         height: 60vh;
+        overflow: auto;
+    };
+    @media screen and (max-width: ${(props) => props.theme.device.laptopL}), screen and (max-height: 820px) {
+        max-height: 500px;
         overflow: auto;
     };
 `;

--- a/suomen-vaylat-app/src/components/user-guide-modal/UserGuideModalContent.jsx
+++ b/suomen-vaylat-app/src/components/user-guide-modal/UserGuideModalContent.jsx
@@ -64,13 +64,27 @@ const StyledGuideContent = styled.div`
     margin-left 20px;
 `;
 
-const StyledIconButton = styled.button`
+const StyledVaylaButton = styled.div`
     border: none;
     border-radius: 50%;
     background: ${theme.colors.mainColor1};
     height: 40px;
     width: 40px;
     pointer-events: none;
+    margin-left: 10px;
+`;
+
+const StyledIconButton = styled.div`
+    border: none;
+    border-radius: 50%;
+    background: ${theme.colors.mainColor1};
+    height: 40px;
+    width: 40px;
+    pointer-events: none;
+    margin-left: 10px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 `;
 
 const StyledFAIcon = styled(FontAwesomeIcon)`
@@ -93,9 +107,9 @@ export const UserGuideModalContent = () => {
     const modalContent = [
         {
             title:  <StyledTitleWrapper>
-                    <StyledIconButton>
+                    <StyledVaylaButton>
                         <VaylaLogo />
-                    </StyledIconButton>
+                    </StyledVaylaButton>
                         <p>{strings.appGuide.modalContent.upperBar.title}</p>
                     </StyledTitleWrapper>,
             content: <StyledGuideContent>
@@ -214,7 +228,7 @@ export const UserGuideModalContent = () => {
                                         }}
                                         icon={faAngleRight}
                                     />
-                                    <p>{content.title}</p>
+                                    {content.title}
                                 </StyledAccordionButton>
                                 <StyledAccordionBody bsPrefix={'user-guide-body'}>
                                     {content.content}

--- a/suomen-vaylat-app/src/theme/theme.js
+++ b/suomen-vaylat-app/src/theme/theme.js
@@ -25,13 +25,13 @@ var isMobileTest = {
 
 export const isMobile = isMobileTest.any();
 
-const size = {
+export const size = {
   mobileS: '320px',
   mobileM: '375px',
   mobileL: '425px',
   tablet: '768px',
   laptop: '1024px',
-  laptopL: '1440px',
+  laptopL: '1640px',
   desktop: '2560px'
 };
 


### PR DESCRIPTION
- improve searchtoast responsiveness on smaller height screens
- fix userguide icons not centered on tablets
- use desktop styling on tablets in appinfomodal
- handle very rare front end crashing when layerlist or theme layers don't receive data

Should be fixed in the future:
- marker options styles on tablets depending on screen orientation
- user guide modal styling responsiveness improvements for tablets