### PR TITLE
Add CQL Filter option

### DIFF
--- a/suomen-vaylat-app/src/components/action-button/ActionButtons.jsx
+++ b/suomen-vaylat-app/src/components/action-button/ActionButtons.jsx
@@ -8,14 +8,15 @@ import {
     faMapMarkedAlt,
     faTimes,
     faExpand,
-    faPencilRuler
+    faPencilRuler,
+    faFilter
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import strings from '../../translations';
 import { selectGroup } from '../../utils/rpcUtil';
 import { ThemeGroupShareButton } from '../share-web-site/ShareLinkButtons';
 
-import { setMinimizeGfi } from '../../state/slices/uiSlice';
+import { setMinimizeGfi, setMinimizeCQLFilterModal } from '../../state/slices/uiSlice';
 
 const GFI_GEOMETRY_LAYER_ID = 'drawtools-geometry-layer';
 
@@ -44,6 +45,27 @@ const StyledActionButton = styled(motion.div)`
     justify-content: space-between;
     align-items: center;
     background-color: ${props => props.type === "gfi" ? props.theme.colors.mainColor1 : props.theme.colors.secondaryColor2};
+    box-shadow: 2px 2px 4px #0000004D;
+    border-radius: 24px;
+    color: ${props => props.theme.colors.mainWhite};
+    pointer-events: auto;
+    svg {
+        color: ${props => props.theme.colors.mainWhite};
+    };
+    @media ${props => props.theme.device.mobileL} {
+        top: initial;
+        max-width: 212px;
+        height: 40px;
+    };
+    z-index:100;
+`;
+
+const StyledFilterActionButton = styled(motion.div)`
+    max-width: 312px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: ${props => props.theme.colors.secondaryColor8};
     box-shadow: 2px 2px 4px #0000004D;
     border-radius: 24px;
     color: ${props => props.theme.colors.mainWhite};
@@ -194,10 +216,12 @@ const ActionButtons = ({
         selectedTheme,
         lastSelectedTheme,
         selectedThemeId,
-        gfiLocations
+        gfiLocations,
+        cqlFilteringInfo
     } = useAppSelector((state) => state.rpc);
     const {
-        minimizeGfi,        
+        minimizeGfi,
+        minimizeCQLFilter        
     } = useAppSelector((state) => state.ui);
 
     const handleSelectGroup = (index, theme) => {
@@ -226,8 +250,8 @@ const ActionButtons = ({
     return (
             <StyledContent>
                     <AnimatePresence initial={false}>
-                        {
-                            minimizeGfi &&
+                        { minimizeGfi &&
+
                             <StyledActionButton
                                 key="gfi_action_button"
                                 type="gfi"
@@ -273,8 +297,8 @@ const ActionButtons = ({
                                 </StyledRightContent>
                             </StyledActionButton>
                         }
-                        {
-                            selectedTheme && selectedTheme !== '' &&
+                        { selectedTheme && selectedTheme !== '' &&
+
                             <StyledActionButton
                                 key="theme_action_button"
                                 positionTransition
@@ -306,6 +330,46 @@ const ActionButtons = ({
                                 </StyledRightContent>
 
                             </StyledActionButton>
+                        }
+                        { minimizeCQLFilter &&
+
+                            <StyledFilterActionButton
+                                key="filter_action_button"
+                                positionTransition
+                                initial={{ y: 50, filter: "blur(10px)", opacity: 0 }}
+                                animate={{ y: 0, filter: "blur(0px)", opacity: 1 }}
+                                exit={{ y: 50, filter: "blur(10px)", opacity: 0 }}
+                                transition={{
+                                    duration: 0.4,
+                                    type: "tween"
+                                }}
+                            >
+                                <StyledLeftContent>
+                                    <StyledActionButtonIcon>
+                                        <FontAwesomeIcon
+                                            icon={faFilter}
+                                        />
+                                    </StyledActionButtonIcon>
+                                    <StyledActionButtonText>{cqlFilteringInfo?.layer?.title}</StyledActionButtonText>
+                                </StyledLeftContent>
+                                <StyledRightContent>
+                                    <StyledExpandButton
+                                        onClick={() => store.dispatch(setMinimizeCQLFilterModal(false))}
+                                    >
+                                        <FontAwesomeIcon
+                                            icon={faExpand}
+                                        />
+                                    </StyledExpandButton>
+                                    <StyledActionButtonClose
+                                        onClick={() => closeAction()}
+                                    >
+                                        <FontAwesomeIcon
+                                            icon={faTimes}
+                                        />
+                                    </StyledActionButtonClose>
+                                </StyledRightContent>
+
+                            </StyledFilterActionButton>
                         }
                     </AnimatePresence>
     </StyledContent>

--- a/suomen-vaylat-app/src/components/filter/CQLFilterModal.jsx
+++ b/suomen-vaylat-app/src/components/filter/CQLFilterModal.jsx
@@ -1,0 +1,512 @@
+import { useState, useContext, useEffect, useRef } from "react";
+import { useAppSelector } from "../../state/hooks";
+import { ReactReduxContext } from "react-redux";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import "dayjs/locale/fi";
+import "dayjs/locale/sv";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+
+import { getCQLStringPropertyOperator, getCQLNumberPropertyOperator } from "../../utils/gfiUtil"
+
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+
+import "react-toastify/dist/ReactToastify.css";
+import styled from "styled-components";
+import strings from "../../translations";
+import Dropdown from "../select/Dropdown";
+import { faPlus, faTimes, faTrash } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
+import { setCQLFilters } from "../../state/slices/rpcSlice";
+
+const StyledFilterProp = styled.div``;
+
+const StyledFilterPropContainer = styled.div`
+  width: 95%;
+`;
+
+const StyledFilterHeader = styled.div`
+  font-size: 16px;
+  font-weight: bold;
+`;
+
+const StyledModalContainer = styled.div`
+  :after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  margin-left: 1em;
+  margin-right: 1em;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  min-width: 20em;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledModalSelectionContainer = styled.div`
+  :after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledModalResultContainer = styled.div`
+  :after {
+    content: "";
+    display: table;
+    clear: both;
+  }
+  margin-top: 1em;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledModalFloatingChapter = styled.div`
+  float: left;
+  height: '3em'
+  width: 100%;
+  position: relative;
+`;
+const StyledModalFloatingActionChapter = styled.div`
+  width: 7%;
+  margin-left: ".5em";
+  float: left;
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+  justify-content: flex-end;
+  align-self: flex-end;
+`;
+
+const StyledInput = styled.input`
+  width: 100%;
+  padding-left: 12px;
+  font-size: 16px;
+  padding-top: 10px;
+  border-radius: 4px;
+  border: 2px solid;
+  border-color: hsl(0, 0%, 80%);
+  padding: 5px 10px;
+`;
+
+const StyledFilterContainer = styled.div`
+  padding-top: 1em;
+  margin-left: ".5em";
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+`;
+
+const StyledFilterResultContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const StyledFilterReusltButtons = styled.div`
+  display: flex;
+  align-items: flex-end;
+`;
+
+const StyledFilter = styled.div`
+  background-color: #f2f2f2;
+  border: solid 1px black;
+  border-radius: 7px;
+  margin-bottom: 5px;
+  padding-left: 3px;
+  padding-right: 3px;
+  :nth-child(odd) {
+    background-color: white;
+  }
+  :nth-child(3) {
+    //float: none;
+  }
+  display: flex;
+`;
+
+const StyledSelectedTabDisplayOptionsButton = styled.div`
+  display: flex;
+  position: relative;
+  right: 0px;
+  margin: 0.5em 0 0.5em 0.5em;
+  cursor: pointer;
+  color: ${(props) => props.theme.colors.mainColor1};
+  svg {
+    font-size: 24px;
+  }
+`;
+
+const StyledTimesIconWrapper = styled.div`
+  margin: 0.5em;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: ${(props) => props.theme.colors.mainColor1};
+  svg {
+    font-size: 20px;
+    transition: all 0.1s ease-out;
+  }
+  &:hover {
+    svg {
+      color: ${(props) => props.theme.colors.mainColor2};
+    }
+  }
+  float: right;
+`;
+
+const StyledTrashIconWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  text-align: end;
+  margin: 1em 0 0 1em;
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: ${(props) => props.theme.colors.mainColor1};
+  svg {
+    font-size: 20px;
+  }
+  &:hover {
+    svg {
+      color: ${(props) => props.theme.colors.mainColor2};
+    }
+  }
+`;
+
+export const CQLFilterModal = () => {
+  const {
+    cqlFilters,
+    cqlFilteringInfo,
+    channel,
+  } = useAppSelector((state) => state.rpc);
+  const { store } = useContext(ReactReduxContext);
+  const [operatorValue, setOperatorValue] = useState({});
+  const [filterValue, setFilterValue] = useState({ value: "", type: null });
+  const [propValue, setPropValue] = useState({});
+  const [fieldNameLocales, setFieldNameLocales] = useState({});
+  const [startDate, setStartDate] = useState(null);
+  const [endDate, setEndDate] = useState(null);
+
+  const handleSetPropValue = (value) => {
+    setStartDate(null);
+    setEndDate(null);
+    setFilterValue({ value: "", type: null });
+    setOperatorValue({});
+    setPropValue(value);
+  };
+
+  const addFilter = () => {
+    const prop = propValue.value;
+    var value;
+    if (startDate || endDate) {
+      value = {
+        start: startDate ? new Date(startDate) : null,
+        end: endDate ? new Date(endDate) : null,
+      };
+    } else {
+      value = filterValue.value;
+    }
+    const type = propValue.type;
+    const oper = type === "date" ? "date" : operatorValue.value;
+    const layer = cqlFilteringInfo?.layer?.id;
+
+    if (!prop || !value) {
+      //lisää popup varoitus
+      return;
+    }
+    store.dispatch(
+      setCQLFilters([
+        ...cqlFilters,
+        {
+          layer: layer,
+          property: prop,
+          operator: oper,
+          value: value,
+          type: type,
+        },
+      ])
+    );
+    setStartDate(null);
+    setEndDate(null);
+    setPropValue({});
+    setFilterValue({ value: "", type: null });
+    setOperatorValue({});
+  };
+
+  const gfiFilteringNumberOptions = [
+    { value: "equals", label: strings.gfifiltering.operators.equals },
+    { value: "notEquals", label: strings.gfifiltering.operators.notEquals },
+    { value: "smallerThan", label: strings.gfifiltering.operators.smallerThan },
+    { value: "biggerThan", label: strings.gfifiltering.operators.biggerThan },
+  ];
+
+  const gfiFilteringStringOptions = [
+    { value: "equals", label: strings.gfifiltering.operators.equals },
+    { value: "notEquals", label: strings.gfifiltering.operators.notEquals },
+    { value: "includes", label: strings.gfifiltering.operators.includes },
+    {
+      value: "doesntInclude",
+      label: strings.gfifiltering.operators.doesntInclude,
+    },
+  ];
+
+  var comparisonOperatorsHash = {
+    number: gfiFilteringNumberOptions,
+    string: gfiFilteringStringOptions,
+  };
+
+  useEffect(() => {
+    var layer = cqlFilteringInfo?.layer;
+    channel.getFieldNameLocales(
+      [layer?.id],
+      (data) => {
+        setFieldNameLocales(data);
+      },
+      (err) => {
+        console.log(err);
+      }
+    );
+  }, []);
+
+  const [activeFilters, setActiveFilters] = useState();
+
+  useEffect(() => {
+    if (cqlFilteringInfo && cqlFilteringInfo?.layer && cqlFilters) {
+      const updatedActivefilters = cqlFilters.filter(
+        (filter) => filter.layer === cqlFilteringInfo?.layer.id
+      );
+      setActiveFilters(updatedActivefilters);
+    }
+  }, [cqlFilters, cqlFilteringInfo]);
+
+const useDidMountEffect = (func, deps) => {
+    const didMount = useRef(false);
+
+    useEffect(() => {
+        if (didMount.current) func();
+        else didMount.current = true;
+    }, deps);
+}
+ 
+useDidMountEffect(() => {
+    let filters = "";
+    cqlFilters && cqlFilters.forEach((filter, index) => {
+        var cqlFilter = filter.type === 'string' ? 
+        getCQLStringPropertyOperator(filter.property, filter.operator, filter.value)
+        :
+        getCQLNumberPropertyOperator(filter.property, filter.operator, filter.value);
+        index === 0 ? filters += cqlFilter : filters += " AND " + cqlFilter;
+    })
+
+    if (filters.length > 0) {
+        channel && channel.postRequest(
+        'MapModulePlugin.MapLayerUpdateRequest',
+        [cqlFilteringInfo.layer.id, true, { 'CQL_FILTER': filters }]
+        );
+    } else {
+        cqlFilteringInfo.layer && channel && channel.postRequest(
+            'MapModulePlugin.MapLayerUpdateRequest',
+            [cqlFilteringInfo.layer.id, true, { 'CQL_FILTER': null }]
+            );
+    }
+  }, [cqlFilters]);
+
+  const handleRemoveFilter = (filter) => {
+    if (cqlFilters && cqlFilters.length > 0 && cqlFilters.includes(filter)) {
+      const updatedFilters = cqlFilters.filter(
+        (existingFilter) => existingFilter !== filter
+      );
+      store.dispatch(setCQLFilters(updatedFilters));
+    }
+  };
+
+  const filterOptions = () => {
+    var layer = cqlFilteringInfo?.layer;
+    const options = layer?.filterColumnsArray.map((column) => {
+      if (Object.keys(fieldNameLocales).length > 0) {
+        return {
+          value: column.key,
+          label: fieldNameLocales[column.title],
+          type: column.type,
+        };
+      } else {
+        return {
+          value: column.key,
+          label: column.title,
+          type: column.type,
+        };
+      }
+    });
+    return options;
+  };
+
+  return (
+    <StyledModalContainer>
+      <StyledModalSelectionContainer>
+        <StyledModalFloatingChapter>
+          <Dropdown
+            options={filterOptions()}
+            placeholder={strings.gfifiltering.placeholders.chooseProp}
+            value={propValue}
+            setValue={(value) => handleSetPropValue(value)}
+            isDisabled={false}
+          />
+        </StyledModalFloatingChapter>
+        {propValue.type === "date" ? (
+          <>
+            <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={strings.getLanguage()}>
+              <DatePicker
+                sx={{ marginTop: ".5em" }}
+                label={strings.gfifiltering.startDate}
+                value={startDate}
+                onChange={(newValue) => setStartDate(newValue)}
+              />
+              <DatePicker
+                sx={{ marginTop: ".5em" }}
+                label={strings.gfifiltering.endDate}
+                value={endDate}
+                onChange={(newValue) => setEndDate(newValue)}
+              />
+            </LocalizationProvider>
+          </>
+        ) : (
+          <>
+            <StyledModalFloatingChapter style={{ marginTop: ".5em" }}>
+              <Dropdown
+                options={comparisonOperatorsHash[propValue.type]}
+                placeholder={strings.gfifiltering.placeholders.chooseOperator}
+                value={operatorValue}
+                setValue={setOperatorValue}
+                isDisabled={Object.keys(propValue).length === 0}
+              />
+            </StyledModalFloatingChapter>
+            <StyledModalFloatingChapter style={{ marginTop: ".5em" }}>
+              <StyledInput
+                type="text"
+                value={filterValue.value}
+                placeholder={strings.gfifiltering.placeholders.chooseValue}
+                onChange={(e) =>
+                  setFilterValue({
+                    value: e.target.value,
+                    type: propValue.type,
+                  })
+                }
+                onKeyPress={(e) => {
+                  if (e.key === "Enter") {
+                    addFilter();
+                  }
+                }}
+                disabled={Object.keys(operatorValue).length === 0}
+              />
+            </StyledModalFloatingChapter>
+          </>
+        )}
+        <StyledModalFloatingActionChapter>
+          <StyledSelectedTabDisplayOptionsButton onClick={() => addFilter()}>
+            {strings.gfifiltering.addFilter}{" "}
+            <FontAwesomeIcon style={{ marginLeft: ".3em" }} icon={faPlus} />
+          </StyledSelectedTabDisplayOptionsButton>
+        </StyledModalFloatingActionChapter>
+      </StyledModalSelectionContainer>
+
+      <StyledModalResultContainer>
+        {activeFilters && activeFilters.length > 0 && (
+          <StyledFilterContainer>
+            <StyledFilterResultContainer>
+              <StyledFilterHeader style={{ marginBottom: ".5em" }}>
+                {strings.gfifiltering.activeFilters}
+              </StyledFilterHeader>
+              {activeFilters.map((filter) => (
+                <StyledFilter>
+                  <StyledFilterPropContainer>
+                    <StyledFilterProp>
+                      {strings.gfifiltering.property}:{" "}
+                      {Object.keys(fieldNameLocales).length > 0 ? fieldNameLocales[filter.property] : filter.property}
+                    </StyledFilterProp>
+                    <StyledFilterProp>
+                      {filter.operator === "date" ? (
+                        <>
+                          {strings.gfifiltering.operator}:{" "}
+                          {strings.gfifiltering.dateRange}{" "}
+                        </>
+                      ) : (
+                        <>
+                          {strings.gfifiltering.operator}:{" "}
+                          {strings.gfifiltering.operators[filter.operator]}{" "}
+                        </>
+                      )}
+                    </StyledFilterProp>
+                    {filter.type === "date" ? (
+                      <>
+                        <StyledFilterProp>
+                          {strings.gfifiltering.startDate}:{" "}
+                          {filter.value.start
+                            ? filter.value.start.toLocaleString([strings.getLanguage()], {
+                                year: "numeric",
+                                month: "numeric",
+                                day: "numeric",
+                              })
+                            : "-"}
+                        </StyledFilterProp>
+                        <StyledFilterProp>
+                          {strings.gfifiltering.endDate}:{" "}
+                          {filter.value.end
+                            ? filter.value.end.toLocaleString([strings.getLanguage()], {
+                                year: "numeric",
+                                month: "numeric",
+                                day: "numeric",
+                              })
+                            : "-"}
+                        </StyledFilterProp>
+                      </>
+                    ) : (
+                      <StyledFilterProp>
+                        {strings.gfifiltering.value}: {filter.value}
+                      </StyledFilterProp>
+                    )}
+                  </StyledFilterPropContainer>
+                  <StyledTimesIconWrapper
+                    onClick={() => {
+                      handleRemoveFilter(filter);
+                    }}
+                  >
+                    <FontAwesomeIcon
+                      icon={faTimes}
+                      size="6x"
+                      style={{ marginLeft: ".5em" }}
+                    />
+                  </StyledTimesIconWrapper>
+                </StyledFilter>
+              ))}
+            </StyledFilterResultContainer>
+            <StyledFilterReusltButtons>
+              <StyledTrashIconWrapper
+                onClick={() => {
+                    store.dispatch(setCQLFilters([]));
+                }}
+              >
+                {strings.gfifiltering.removeAllFilters}{" "}
+                <FontAwesomeIcon
+                  icon={faTrash}
+                  size="6x"
+                  style={{ marginLeft: ".5em" }}
+                />
+              </StyledTrashIconWrapper>
+            </StyledFilterReusltButtons>
+          </StyledFilterContainer>
+        )}
+      </StyledModalResultContainer>
+    </StyledModalContainer>
+  );
+};

--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -577,7 +577,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
         var featureCells =
           cont.geojson.features &&
           cont.geojson.features
-            .filter((feature) => filterFeature(feature, data, filters))
+            .filter((feature) => filterFeature(feature, data, filters, channel))
             .map((feature) => {
               var cell = { ...feature.properties };
               cell["id"] = feature.id;

--- a/suomen-vaylat-app/src/components/layout/Content.jsx
+++ b/suomen-vaylat-app/src/components/layout/Content.jsx
@@ -982,6 +982,10 @@ const Content = () => {
           layerId={cqlFilteringInfo?.layer?.id}
           minimize={minimizeCQLFilter}
           maximize={maximizeCQLFilter}
+          minimizable={true}
+          maximizable={true}
+          minimizeAction={() => store.dispatch(setMinimizeCQLFilterModal(!minimizeCQLFilter))}
+          maximizeAction={() => store.dispatch(setMaximizeCQLFilterModal(!maximizeCQLFilter))}
           minWidth={"25em"}
           minHeight={"30em"}
           overflow={"auto"}

--- a/suomen-vaylat-app/src/components/modals/Modal.jsx
+++ b/suomen-vaylat-app/src/components/modals/Modal.jsx
@@ -185,6 +185,10 @@ const Modal = ({
     minWidth,
     maxWidth,
     overflow,
+    minimizable,
+    minimizeAction,
+    maximizable,
+    maximizeAction,
     minimize,
     maximize,
     children,
@@ -272,29 +276,27 @@ const Modal = ({
                                     <p>{title}</p>
                                 </StyledModalTitle>
                                 <StyledRightContent>
-                                    {type === 'gfi' && (
-                                        <>
+                                    {minimizable && (
                                             <StyledHeaderButton
-                                                onClick={() => store.dispatch(setMinimizeGfi(true))}
+                                                onClick={() => minimizeAction()}
                                             >
                                                 <FontAwesomeIcon
                                                     icon={faWindowMinimize}
                                                 />
                                             </StyledHeaderButton>
-                                            {
-                                                window.screen.width > MIN_SCREEN_WIDTH_MAXIMIZE &&
-                                                    <StyledHeaderButton
-                                                        onClick={(e) => {
-                                                            e.preventDefault();
-                                                            store.dispatch(setMaximizeGfi(!maximize));
-                                                        }}
-                                                    >
-                                                        <FontAwesomeIcon
-                                                            icon={maximize ? faWindowRestore : faWindowMaximize}
-                                                        />
-                                                    </StyledHeaderButton>
-                                            }
-                                        </>
+                                    )}
+
+                                    { maximizable && window.screen.width > MIN_SCREEN_WIDTH_MAXIMIZE && (
+                                        <StyledHeaderButton
+                                            onClick={(e) => {
+                                                e.preventDefault();
+                                                maximizeAction();
+                                            }}
+                                        >
+                                            <FontAwesomeIcon
+                                                icon={maximize ? faWindowRestore : faWindowMaximize}
+                                            />
+                                        </StyledHeaderButton>
                                     )}
 
                                     {hasHelp && (

--- a/suomen-vaylat-app/src/state/slices/rpcSlice.jsx
+++ b/suomen-vaylat-app/src/state/slices/rpcSlice.jsx
@@ -59,8 +59,10 @@ const initialState = {
   },
   pointInfo: {},
   filters: [],
+  cqlFilters: [],
   activeGFILayer: null,
   filteringInfo: { modalOpen: false },
+  cqlFilteringInfo: { modalOpen: false }
 };
 
 export const rpcSlice = createSlice({
@@ -80,7 +82,7 @@ export const rpcSlice = createSlice({
 
     /**
      * Set selected layer on gfi popup
-     * @method setLoading
+     * @method setActiveGFILayer
      * @param {Object} state
      * @param {Object} action
      */
@@ -101,7 +103,7 @@ export const rpcSlice = createSlice({
 
     /**
      * Set filters.
-     * @method setChannel
+     * @method setFilters
      * @param {Object} state
      * @param {Object} action
      */
@@ -110,13 +112,33 @@ export const rpcSlice = createSlice({
     },
 
     /**
-     * Set filters.
+     * Set CQL filters.
      * @method setChannel
+     * @param {Object} state
+     * @param {Object} action
+     */
+    setCQLFilters: (state, action) => {
+      state.cqlFilters = action.payload;
+    },
+
+    /**
+     * Set filtering info.
+     * @method setFilteringInfo
      * @param {Object} state
      * @param {Object} action
      */
     setFilteringInfo: (state, action) => {
       state.filteringInfo = action.payload;
+    },
+
+    /**
+     * Set CQL filtering info.
+     * @method setCQLFilteringInfo
+     * @param {Object} state
+     * @param {Object} action
+     */
+    setCQLFilteringInfo: (state, action) => {
+      state.cqlFilteringInfo = action.payload;
     },
 
     /**
@@ -131,19 +153,9 @@ export const rpcSlice = createSlice({
     },
 
     /**
-     * Set maplayer filter
-     * @method setFilter
-     * @param {Object} state
-     * @param {Object} action
-     */
-    setFilter: (state, action) => {
-      state.filter = action.payload;
-      LOG.log("setFilter to " + action.payload);
-    },
-
-    /**
      * Set all layers.
      * Not use this function directly, use rpcUtil/updateLayers function.
+     * @method setAllLayers
      * @param {Object} state
      * @param {Object} action
      */
@@ -914,7 +926,6 @@ export const {
   setLastSelectedTheme,
   setSelectedThemeId,
   setActiveAnnouncements,
-  setFilter,
   getLayerMetadata,
   clearLayerMetadata,
   setLayerMetadata,
@@ -941,9 +952,11 @@ export const {
   setMapLayers,
   setAllSelectedThemeLayers,
   setPointInfo,
+  setCQLFilters,
   setFilters,
   setActiveGFILayer,
   setFilteringInfo,
+  setCQLFilteringInfo
 } = rpcSlice.actions;
 
 export default rpcSlice.reducer;

--- a/suomen-vaylat-app/src/state/slices/uiSlice.jsx
+++ b/suomen-vaylat-app/src/state/slices/uiSlice.jsx
@@ -20,6 +20,7 @@ const initialState = {
     savedTabIndex: 0,
     isUserGuideOpen: false,
     isCustomFilterOpen: false,
+    isCQLFilterModalOpen: false,
     isSavedLayer: false,
     shareUrl: '',
     isThemeMenuOpen: false,
@@ -38,6 +39,8 @@ const initialState = {
     selectedMapLayersMenuThemeIndex: null,
     minimizeGfi: false,
     maximizeGfi: false,
+    minimizeCQLFilter: false,
+    maximizeCQLFilter: false,
     gfiCroppingTypes: [],
     warning: null,
     hasToastBeenShown : [],
@@ -174,6 +177,12 @@ export const uiSlice = createSlice({
         setMaximizeGfi: (state, action) => {
             state.maximizeGfi = action.payload;
         },
+        setMinimizeCQLFilterModal: (state, action) => {
+            state.minimizeCQLFilter = action.payload;
+        },
+        setMaximizeCQLFilterModal: (state, action) => {
+            state.maximizeCQLFilter = action.payload;
+        },
         setGfiCroppingTypes: (state, action) => {
             state.gfiCroppingTypes = action.payload;
         },
@@ -212,6 +221,9 @@ export const uiSlice = createSlice({
         setIsGfiToolsOpen: (state, action) => {
             state.isGfiToolsOpen = action.payload;
         },
+        setIsCQLFilterModalOpen: (state, action) => {
+            state.isCQLFilterModalOpen = action.payload;
+        },
         incrementTriggerUpdate: state => {
             state.triggerUpdate += 1; // increment value
           },
@@ -220,6 +232,9 @@ export const uiSlice = createSlice({
 });
 
 export const {
+    setMinimizeCQLFilterModal,
+    setMaximizeCQLFilterModal,
+    setIsCQLFilterModalOpen,
     setIsFullScreen,
     setIsMainScreen,
     setModalConstrainsRef,

--- a/suomen-vaylat-app/src/translations/en.json
+++ b/suomen-vaylat-app/src/translations/en.json
@@ -74,6 +74,7 @@
   },
   "gfi": {
     "filter": "Filter",
+    "cqlFilter": "Filter on map",
     "title": "Feature Data",
     "close": "Close",
     "additionalInfo": "Additional information",

--- a/suomen-vaylat-app/src/translations/fi.json
+++ b/suomen-vaylat-app/src/translations/fi.json
@@ -101,6 +101,7 @@
       "disabled": "Väliaikaisesti poissa käytöstä"
     },
     "filter" : "Suodata",
+    "cqlFilter" : "Suodata kartalla",
     "streetView": {
       "title": "Google Street View",
       "openGoogleStreetView": "Avaa Google Street View",

--- a/suomen-vaylat-app/src/translations/sv.json
+++ b/suomen-vaylat-app/src/translations/sv.json
@@ -74,6 +74,7 @@
   },
   "gfi": {
     "filter": "Filtrera",
+    "cqlFilter": "Filter på kartan",
     "title": "Objektuppgifter",
     "close": "Stänga",
     "additionalInfo": "Tilläggsinformation",

--- a/suomen-vaylat-app/src/utils/gfiUtil.jsx
+++ b/suomen-vaylat-app/src/utils/gfiUtil.jsx
@@ -116,7 +116,6 @@ export const filterFeature = (feature, location, filters, channel) => {
   };
 
   const properties = feature.keyValueProperties;
-  //let cqlFilters = "";
   const filterMatch = filters.every((filter) => {
 
     if (location.layerId === filter.layer && filter.type !== "date") {
@@ -149,25 +148,6 @@ export const filterFeature = (feature, location, filters, channel) => {
       return true;
     }
   });
-
-  /*
-  filters.forEach((filter, index) => {
-    var cqlFilter = filter.type === 'string' ? 
-      getCQLStringPropertyOperator(filter.property, filter.operator, filter.value)
-      :
-      getCQLNumberPropertyOperator(filter.property, filter.operator, filter.value);
-    index === 0 ? cqlFilters += cqlFilter : cqlFilters += " AND " + cqlFilter;
-    console.log(cqlFilters)
-  })
-
-  if (cqlFilters.length > 0) {
-    console.log(cqlFilters)
-    channel && channel.postRequest(
-      'MapModulePlugin.MapLayerUpdateRequest',
-      [location.layerId, true, { 'CQL_FILTER': cqlFilters }]
-    );
-  }
-  */
 
   return filterMatch;
 };


### PR DESCRIPTION
Add the ability filter layer on map with CQL filters. Same options that GFI result filtering uses, same logic and same requirements. Updates the map results according to filters. Can be maximized and minimized, filters get deleted if the popup is closed.

Filter on:
![activecql](https://github.com/finnishtransportagency/suomen-vaylat/assets/13982559/71d55b2b-6ac2-4951-be36-86dee67fff5a)

Minimized filter popup:
![minifiedCQL](https://github.com/finnishtransportagency/suomen-vaylat/assets/13982559/d9b795df-929a-4005-a562-e33e5addf831)

Filter button:
![cqlfilterbutton](https://github.com/finnishtransportagency/suomen-vaylat/assets/13982559/a441e86f-bc9f-44af-81f9-0364311b11d3)
