### PR TITLE
Fix issue with double markers for clicked point

### DIFF
--- a/suomen-vaylat-app/src/components/gfi/FormattedGFI.jsx
+++ b/suomen-vaylat-app/src/components/gfi/FormattedGFI.jsx
@@ -360,7 +360,7 @@ const selectFeature = (channel, features) => {
         },
         image: {
             shape: 2,
-            size: 5,
+            size: 4,
             offsetX: 13,
             offsetY: 7,
             fill: {

--- a/suomen-vaylat-app/src/components/gfi/FormattedGFI.jsx
+++ b/suomen-vaylat-app/src/components/gfi/FormattedGFI.jsx
@@ -361,8 +361,6 @@ const selectFeature = (channel, features) => {
         image: {
             shape: 2,
             size: 4,
-            offsetX: 13,
-            offsetY: 7,
             fill: {
                 color: '#e50083',
             }

--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -30,6 +30,7 @@ import {
   addFeaturesToGFILocations,
   setActiveGFILayer,
   setFilters,
+  removeMarkerRequest
 } from "../../state/slices/rpcSlice";
 import { FormattedGFI } from "./FormattedGFI";
 import GfiTabContent from "./GfiTabContent";
@@ -612,6 +613,7 @@ export const GFIPopup = ({ handleGfiDownload }) => {
       };
 
       channel.postRequest(rn, [geojsonObject, options]);
+      store.dispatch(removeMarkerRequest({ markerId: "VKM_MARKER" }));
     }
   }
 
@@ -831,7 +833,6 @@ export const GFIPopup = ({ handleGfiDownload }) => {
 
   useEffect(() => {
     vkmData ? setIsVKMInfoOpen(true) : setIsVKMInfoOpen(false);
-
     if (pointInfo.lon && pointInfo.lat) {
       // our projection EPSG:3067
       var oskariProjection =

--- a/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GFIPopup.jsx
@@ -567,6 +567,8 @@ export const GFIPopup = ({ handleGfiDownload }) => {
         LAYER_ID,
       ]);
     } else {
+      store.dispatch(removeMarkerRequest({ markerId: "VKM_MARKER" }));
+      
       let featureStyle = {
         fill: {
             color: 'rgba(10, 140, 247, 0.3)',
@@ -613,7 +615,6 @@ export const GFIPopup = ({ handleGfiDownload }) => {
       };
 
       channel.postRequest(rn, [geojsonObject, options]);
-      store.dispatch(removeMarkerRequest({ markerId: "VKM_MARKER" }));
     }
   }
 


### PR DESCRIPTION
remove vkm marker when adding the overlay geometry for GFI window when clicked point contains a feature