### PR TITLE
Add info button to open a link to filtering info

### DIFF
--- a/suomen-vaylat-app/src/components/gfi/GfiTabContent.jsx
+++ b/suomen-vaylat-app/src/components/gfi/GfiTabContent.jsx
@@ -173,6 +173,7 @@ const GfiTabContent = ({ layer, data, title, tablePropsInit }) => {
             layer: {
               id: layer.id,
               title: layer.name,
+              filterFieldsInfo: layer.config?.gfi?.filterFieldsInfo || null,
               filterColumnsArray: filterColumnsArray
             }
         }

--- a/suomen-vaylat-app/src/translations/en.json
+++ b/suomen-vaylat-app/src/translations/en.json
@@ -8,6 +8,7 @@
   },
   "title": "Suomen Väylät",
   "tooltips": {
+    "showInfoLink": "Filtering info (opens in a new tab)",
     "layerlist": {
       "filter": "Filter",
       "filterable": "Filterable layer",

--- a/suomen-vaylat-app/src/translations/fi.json
+++ b/suomen-vaylat-app/src/translations/fi.json
@@ -8,6 +8,7 @@
   },
   "title": "Suomen Väylät",
   "tooltips": {
+    "showInfoLink": "Suodatus info (avautuu uuteen välilehteen)",
     "layerlist": {
       "filter": "Suodata",
       "filterable": "Suodatettava taso",

--- a/suomen-vaylat-app/src/translations/sv.json
+++ b/suomen-vaylat-app/src/translations/sv.json
@@ -8,6 +8,7 @@
   },
   "title": "Suomen Väylät",
   "tooltips": {
+    "showInfoLink": "Filtreringsinformation (öppnas på en ny flik)",
     "layerlist": {
       "filter": "Filtrera",
       "filterable": "Filtrerbart kartlager",


### PR DESCRIPTION
Added a info button to filtering modal where we can have a link to external source for information about the current layer's filtering options.

In order to add the link, we add line to layer's attributes' data -> gfi block:
`'filterFieldsInfo': 'https://example.com'`